### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ RUN mkdir -p /quickstart /home/nodejs && \
     chown -R nodejs:nodejs /home/nodejs
 
 WORKDIR /quickstart
-COPY . /quickstart/
-RUN chown -R nodejs:nodejs /quickstart
+COPY package.json typings.json /quickstart/
+RUN npm install --unsafe-perm=true
 
+COPY . /quickstart
+RUN chown -R nodejs:nodejs /quickstart
 USER nodejs
-RUN npm install
 
 CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# To build and run with Docker:
+#
+#  $ docker build -t ng2-quickstart .
+#  $ docker run -it --rm -p 3000:3000 -p 3001:3001 ng2-quickstart
+#
+FROM node:latest
+
+RUN mkdir -p /quickstart /home/nodejs && \
+    groupadd -r nodejs && \
+    useradd -r -g nodejs -d /home/nodejs -s /sbin/nologin nodejs && \
+    chown -R nodejs:nodejs /home/nodejs
+
+WORKDIR /quickstart
+COPY . /quickstart/
+RUN chown -R nodejs:nodejs /quickstart
+
+USER nodejs
+RUN npm install
+
+CMD npm start

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "tsc:w": "tsc -w",
     "lite": "lite-server",
     "typings": "typings",
+    "docker-build": "docker build -t ng2-quickstart .",
+    "docker-run": "docker run -it --rm -p 3000:3000 -p 3001:3001 ng2-quickstart",
     "postinstall": "typings install"
   },
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lite": "lite-server",
     "typings": "typings",
     "docker-build": "docker build -t ng2-quickstart .",
-    "docker-run": "docker run -it --rm -p 3000:3000 -p 3001:3001 ng2-quickstart",
+    "docker": "npm run docker-build && docker run -it --rm -p 3000:3000 -p 3001:3001 ng2-quickstart",
     "postinstall": "typings install"
   },
   "license": "ISC",


### PR DESCRIPTION
Adds a Dockerfile and npm scripts to build/run the quickstart with Docker.

Usage:
- To build and run the quickstart in a Docker container: `npm run docker`

Sharing this primarily as an example, since [Docker image building with npm postinstall scripts](https://github.com/jspm/jspm-cli/issues/865) is not always straightforward. 

Docker has also been helpful in troubleshooting Linux-OS related issues in [`lite-server`](https://github.com/johnpapa/lite-server).