### PR TITLE
clean up npm scripts tasks with npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "tsc:w": "tsc -w",
     "lite": "lite-server",
     "typings": "typings",
-    "docker-build": "docker build -t ng2-quickstart .",
-    "docker": "npm run docker-build && docker run -it --rm -p 3000:3000 -p 3001:3001 ng2-quickstart",
+    "docker:build": "docker build -t ng2-quickstart .",
+    "docker:run": "docker run -it --rm -p 3000:3000 -p 3001:3001 ng2-quickstart",
+    "docker": "npm-run-all docker:build docker:run",
     "postinstall": "typings install"
   },
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular2-quickstart",
   "version": "1.0.0",
   "scripts": {
-    "start": "concurrently \"npm run tsc:w\" \"npm run lite\" ",
+    "start": "npm-run-all --parallel tsc:w lite",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "lite": "lite-server",
@@ -21,9 +21,9 @@
     "zone.js": "0.6.6"
   },
   "devDependencies": {
-    "concurrently": "^2.0.0",
     "lite-server": "^2.1.0",
+    "npm-run-all": "^1.7.0",
     "typescript": "^1.8.9",
-    "typings":"^0.7.11"
+    "typings": "^0.7.11"
   }
 }


### PR DESCRIPTION
Hi this is just a suggestion. 

It does not change behavior of the npm scripts tasks but it uses `npm-run-all` instead of concurrently to run tasks in sequence or in parallel. It makes the scripts just nicer to read.
Also I made the task names more consistent by using colon in task names instead of a dash.