### PR TITLE
chore: switch from concurrently to npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular2-quickstart",
   "version": "1.0.0",
   "scripts": {
-    "start": "tsc && concurrently \"npm run tsc:w\" \"npm run lite\" ",
+    "start": "tsc && npm-run-all --parallel tsc:w lite",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "lite": "lite-server",
@@ -22,7 +22,7 @@
     "zone.js": "0.6.6"
   },
   "devDependencies": {
-    "concurrently": "^2.0.0",
+    "npm-run-all": "^1.7.0",
     "lite-server": "^2.2.0",
     "typescript": "^1.8.9",
     "typings":"^0.7.12"


### PR DESCRIPTION
See PR #54 which I accidentally merged prematurely.

STILL not ready to do it ... and if we did, should also update all of angular.io accordingly. 

Too much work for too little reward at this time.
