### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ Here are the test related scripts:
 * `npm webdriver:update` - ONE TIME update for protractor end-to-end (e2e) tests
 * `npm run e2e` - run protractor e2e tests, written in JavaScript (*e2e-spec.js)
 
+## Nitrous Quickstart
+You can quickly create a free development environment for this Angular 2 QuickStart project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Angular 2 Quickstart via `Run > Start Angular 2 Quickstart` and access your site via `Preview > 3000`.
+
 ## Testing
 
 The QuickStart documentation doesn't discuss testing. 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Angular 2 Quickstart project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Angular 2 Quickstart via "Run > Start Angular 2 Quickstart"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "nodejs",
+  "ports": [3000],
+  "name": "Angular 2 Quickstart",
+  "description": "Angular 2 QuickStart Source",
+  "scripts": {
+    "post-create": "cd ~/code/quickstart && echo 'start npm install' && npm install --no-progress && echo 'npm install done'",
+    "Start Angular 2 Quickstart": "cd ~/code/quickstart && npm start"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.