### PR TITLE
chore(readme): fix typo in webdriver command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ the foundation for most of the documentation samples and potentially a good star
 
 It's been extended with testing support so you can start writing tests immediately.
 
-**This is not the perfect arrangement for your application. It is not designed for production. 
+**This is not the perfect arrangement for your application. It is not designed for production.
 It exists primarily to get you started quickly with learning and prototyping in Angular 2**
 
 We are unlikely to accept suggestions about how to grow this QuickStart into something it is not.
@@ -54,7 +54,7 @@ npm install
 npm start
 ```
 
-The `npm start` command first compiles the application, 
+The `npm start` command first compiles the application,
 then simultaneously re-compiles and runs the `lite-server`.
 Both the compiler and the server watch for file changes.
 
@@ -78,12 +78,12 @@ with excellent support for Angular apps that use routing.
 
 Here are the test related scripts:
 * `npm test` - compiles, runs and watches the karma unit tests
-* `npm webdriver:update` - ONE TIME update for protractor end-to-end (e2e) tests
+* `npm run webdriver:update` - ONE TIME update for protractor end-to-end (e2e) tests
 * `npm run e2e` - run protractor e2e tests, written in JavaScript (*e2e-spec.js)
 
 ## Testing
 
-The QuickStart documentation doesn't discuss testing. 
+The QuickStart documentation doesn't discuss testing.
 This repo adds both karma/jasmine unit test and protractor end-to-end testing support.
 
 These tools are configured for specific conventions described below.
@@ -115,13 +115,13 @@ The `HTML-Reporter` is also wired in. That produces a prettier output; look for 
 
 **BEFORE RUNNING THE FIRST TEST** you must update the Selenium webdriver. Run `npm webdriver:update`.
 
-E2E tests are usually at the project root, above the `app` folder. 
+E2E tests are usually at the project root, above the `app` folder.
 Their filenames must end in `e2e-spec.js`.
 
 E2E tests must be written in JavaScript (the author has not figured out how to write them in TS yet).
 
 Look for the example `e2e-spec.ts` in the root folder.
-Add more `e2e-spec.js` files as you wish (although one usually suffices for small projects); 
+Add more `e2e-spec.js` files as you wish (although one usually suffices for small projects);
 we configured protractor to find them.
 
 
@@ -131,7 +131,7 @@ That command first compiles, then simultaneously starts the Http-Server at `loca
 and launches protractor.  
 
 The pass/fail test results appear at the bottom of the terminal window.
-A custom reporter (see `protractor.config.js`) generates a  `./protractor-results.txt` file 
+A custom reporter (see `protractor.config.js`) generates a  `./protractor-results.txt` file
 which is easier to read; this file is excluded from source control.
 
 Shut it down manually with Ctrl-C.


### PR DESCRIPTION
Fixes small typo in the readme.

`npm webdriver:update` should read `npm run webdriver:update`.