### PR TITLE
chore: performance tweaks to wallaby config

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "angular2": "2.0.0-beta.15",
+    "angular2": "2.0.0-beta.16",
     "systemjs": "0.19.26",
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",

--- a/wallaby.js
+++ b/wallaby.js
@@ -7,11 +7,13 @@ module.exports = function () {
     files: [
       {pattern: 'node_modules/es6-shim/es6-shim.js', instrument: false},
       {pattern: 'node_modules/systemjs/dist/system-polyfills.js', instrument: false},
+      {pattern: 'node_modules/angular2/bundles/angular2-polyfills.js', instrument: false},
       {pattern: 'node_modules/systemjs/dist/system.js', instrument: false},
-      {pattern: 'node_modules/reflect-metadata/Reflect.js', instrument: false},
-      {pattern: 'node_modules/zone.js/dist/zone.js', instrument: false},
-      {pattern: 'node_modules/zone.js/dist/long-stack-trace-zone.js', instrument: false},
-      {pattern: 'node_modules/zone.js/dist/jasmine-patch.js', instrument: false},
+      {pattern: 'node_modules/rxjs/bundles/Rx.js', instrument: false},
+      {pattern: 'node_modules/angular2/bundles/angular2.dev.js', instrument: false},
+      {pattern: 'node_modules/angular2/bundles/http.dev.js', instrument: false},
+      {pattern: 'node_modules/angular2/bundles/router.dev.js', instrument: false},
+      {pattern: 'node_modules/angular2/bundles/testing.dev.js', instrument: false},
 
       {pattern: 'app/**/*+(ts|html|css)', load: false},
       {pattern: 'app/**/*.spec.ts', ignore: true}
@@ -31,22 +33,15 @@ module.exports = function () {
       wallaby.delayStart();
 
       System.config({
-        defaultJSExtensions: true,
         packages: {
           app: {
+            defaultExtension: 'js',
             meta: {
               '*': {
                 scriptLoad: true
               }
             }
           }
-        },
-        paths: {
-          'npm:*': 'node_modules/*'
-        },
-        map: {
-          'angular2': 'npm:angular2',
-          'rxjs': 'npm:rxjs'
         }
       });
 

--- a/wallaby.js
+++ b/wallaby.js
@@ -8,6 +8,7 @@ module.exports = function () {
       {pattern: 'node_modules/es6-shim/es6-shim.js', instrument: false},
       {pattern: 'node_modules/systemjs/dist/system-polyfills.js', instrument: false},
       {pattern: 'node_modules/angular2/bundles/angular2-polyfills.js', instrument: false},
+      {pattern: 'node_modules/zone.js/dist/async-test.js', instrument: false},
       {pattern: 'node_modules/systemjs/dist/system.js', instrument: false},
       {pattern: 'node_modules/rxjs/bundles/Rx.js', instrument: false},
       {pattern: 'node_modules/angular2/bundles/angular2.dev.js', instrument: false},


### PR DESCRIPTION
- Using bundles for ng-2 components.
- Using `angular2-polyfills` instead of zone.js and reflect-metadata.