### PR TITLE
Added semicolon after variable declaration.

### DIFF
--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -40,7 +40,7 @@
   var config = {
     map: map,
     packages: packages
-  }
+  };
 
   System.config(config);
 


### PR DESCRIPTION
The linter is complaining about the missing semicolon, so I added it.