### PR TITLE
Fix many 'Can not find name xxxx' issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Install the npm packages described in the `package.json` and verify that it work
 
 ```bash
 npm install
+typings install
 npm start
 ```
 


### PR DESCRIPTION
Hello, I'm using node 4.2.6, npm 2.14.12. 
After `npm install` and `npm start`, it will throw many *Cannot find name xxxx* errors.
Then exits with follow errors.
```bash
npm ERR! Darwin 14.5.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "start"
npm ERR! node v4.2.6
npm ERR! npm  v2.14.12
npm ERR! code ELIFECYCLE
npm ERR! angular2-quickstart@1.0.0 start: `tsc && concurrently "tsc -w" "lite-server" `
npm ERR! Exit status 2
```
After run `typings install` will solve the issue.