### PR TITLE
chore: make SystemJS recognize package.json

### DIFF
--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -3,45 +3,19 @@
  * Adjust as necessary for your application needs.
  * Override at the last minute with global.filterSystemConfig (as plunkers do)
  */
-(function(global) {
-
-  // map tells the System loader where to look for things
-  var map = {
-    'app':                        'app', // 'dist',
-    'rxjs':                       'node_modules/rxjs',
-    'angular2-in-memory-web-api': 'node_modules/angular2-in-memory-web-api',
-    '@angular':                   'node_modules/@angular'
-  };
-
-  // packages tells the System loader how to load when no filename and/or no extension
-  var packages = {
-    'app':                        { main: 'main.js',  defaultExtension: 'js' },
-    'rxjs':                       { defaultExtension: 'js' },
-    'angular2-in-memory-web-api': { defaultExtension: 'js' },
-  };
-
-  var packageNames = [
-    '@angular/common',
-    '@angular/compiler',
-    '@angular/core',
-    '@angular/http',
-    '@angular/platform-browser',
-    '@angular/platform-browser-dynamic',
-    '@angular/router-deprecated',
-    '@angular/testing',
-    '@angular/upgrade',
-  ];
-
-  // add package entries for angular packages in the form '@angular/common': { main: 'index.js', defaultExtension: 'js' }
-  packageNames.forEach(function(pkgName) {
-    packages[pkgName] = { main: 'index.js', defaultExtension: 'js' };
+(function (global) {
+  System.config({
+    defaultJSExtensions: true,
+    packages: {
+      'app': {
+        main: 'main.js'
+      }
+    },
+    paths: {
+      '*': './node_modules/*',
+      'app/': 'app/'
+    },
+    packageConfigPaths: ['./node_modules/*/package.json', './node_modules/@angular/*/package.json']
   });
-
-  var config = {
-    map: map,
-    packages: packages
-  };
-
-  System.config(config);
-
 })(this);
+


### PR DESCRIPTION
Thanks to `packageConfigPaths` option systemjs.config.js can be simplified a lot.