### PR TITLE
chore: add required node and npm versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Please keep that in mind before posting issues and PRs.
 
 ## Create a new project based on the QuickStart
 
+### Dependencies
+
+What you need to run this app:
+* `node` and `npm` (We recommend [NVM](https://github.com/creationix/nvm))
+* Ensure you're running Node `v5.x.x` and NPM `3.x.x`
+
+### Clone the repo
+
 Clone this repo into new project folder (e.g., `my-proj`).
 ```bash
 git clone  https://github.com/angular/quickstart  my-proj


### PR DESCRIPTION
Please @wardbell merge this. Node 4.x and 6.x is giving issues, as well as npm 2.x. Perhaps we can avoid more issues on "npm install doesn't work".