### PR TITLE
Build for RC3 fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@angular/platform-browser":  "2.0.0-rc.3",
     "@angular/platform-browser-dynamic":  "2.0.0-rc.3",
     "@angular/router":  "3.0.0-alpha.7",
-    "@angular/router-deprecated":  "2.0.0-rc.2",
     "@angular/upgrade":  "2.0.0-rc.3",
 
     "systemjs": "0.19.27",
@@ -38,7 +37,6 @@
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12",
 
-    "angular2-in-memory-web-api": "0.0.12",
     "bootstrap": "^3.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Removed obsolete `@angular/router-deprecated`dependency
Removed `angular2-in-memory-web-api` dependency. Could be restored after v 0.0.13 will be published, but actually it's not a part of Quickstart