### PR TITLE
chore: update to @types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea
-typings/**
 node_modules
 jspm_packages
 link-checker-results.txt
@@ -14,5 +13,4 @@ _temp
 !karma*.js
 !protractor*.js
 !systemjs.config.js
-!typings/typings.d.ts
 !wallaby.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /quickstart /home/nodejs && \
     chown -R nodejs:nodejs /home/nodejs
 
 WORKDIR /quickstart
-COPY package.json typings.json /quickstart/
+COPY package.json /quickstart/
 RUN npm install --unsafe-perm=true
 
 COPY . /quickstart

--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ npm install
 npm start
 ```
 
-> If the `typings` folder doesn't show up after `npm install` please install them manually with:
-
-> `npm run typings -- install`
-
 The `npm start` command first compiles the application, 
 then simultaneously re-compiles and runs the `lite-server`.
 Both the compiler and the server watch for file changes.
@@ -94,8 +90,7 @@ We've captured many of the most useful commands in npm scripts defined in the `p
 [John Papa](https://github.com/johnpapa) and
 [Christopher Martin](https://github.com/cgmartin)
 with excellent support for Angular apps that use routing.
-* `npm run typings` - runs the typings tool.
-* `npm run postinstall` - called by *npm* automatically *after* it successfully completes package installation. This script installs the TypeScript definition files this app requires.
+
 Here are the test related scripts:
 * `npm test` - compiles, runs and watches the karma unit tests
 * `npm run e2e` - run protractor e2e tests, written in JavaScript (*e2e-spec.js)

--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { browser, element, by } from 'protractor';
 
 describe('QuickStart E2E Tests', function () {
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,10 @@
     "e2e": "tsc && concurrently \"http-server -s\" \"protractor protractor.config.js\" --kill-others --success first",
     "lint": "tslint ./app/**/*.ts -t verbose",
     "lite": "lite-server",
-    "postinstall": "typings install",
     "test": "tsc && concurrently \"tsc -w\" \"karma start karma.conf.js\"",
     "test-once": "tsc && karma start karma.conf.js --single-run",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
-    "typings": "typings",
     "webdriver:update": "webdriver-manager update"
   },
   "keywords": [],
@@ -49,7 +47,6 @@
     "concurrently": "^3.0.0",
     "lite-server": "^2.2.2",
     "typescript": "^2.0.3",
-    "typings": "^1.4.0",
 
     "canonical-path": "0.0.2",
     "http-server": "^0.9.0",
@@ -62,8 +59,13 @@
     "karma-htmlfile-reporter": "^0.3.4",
     "karma-jasmine": "^1.0.2",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "^3.3.0",
-    "rimraf": "^2.5.4"
+    "protractor": "^4.0.9",
+    "rimraf": "^2.5.4",
+
+    "@types/core-js": "^0.9.34",
+    "@types/node": "^6.0.45",
+    "@types/jasmine": "^2.5.35",
+    "@types/selenium-webdriver": "^2.53.32"
   },
   "repository": {}
 }

--- a/protractor.config.js
+++ b/protractor.config.js
@@ -49,8 +49,6 @@ exports.config = {
     // console.log('browser.params:' + JSON.stringify(browser.params));
     jasmine.getEnv().addReporter(new Reporter( browser.params )) ;
 
-    global.sendKeys = sendKeys;
-
     // Allow changing bootstrap mode to NG1 for upgrade tests
     global.setProtractorToNg1Mode = function() {
       browser.useAllAngular2AppRoots = false;
@@ -65,16 +63,6 @@ exports.config = {
     print: function() {}
   }
 };
-
-// Hack - because of bug with protractor send keys
-function sendKeys(element, str) {
-  return str.split('').reduce(function (promise, char) {
-    return promise.then(function () {
-      return element.sendKeys(char);
-    });
-  }, element.getAttribute('value'));
-  // better to create a resolved promise here but ... don't know how with protractor;
-  }
 
 // Custom reporter
 function Reporter(options) {

--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,0 @@
-{
-  "globalDependencies": {
-    "angular-protractor": "registry:dt/angular-protractor#1.5.0+20160425143459",
-    "core-js": "registry:dt/core-js#0.0.0+20160725163759",
-    "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
-    "node": "registry:dt/node#6.0.0+20160831021119",
-    "selenium-webdriver": "registry:dt/selenium-webdriver#2.44.0+20160317120654"
-  }
-}


### PR DESCRIPTION
This PR updates the quickstart to use the `@types/*` repos. Additionally, it also updates to protractor4 to make use of it's own typings.

/cc @wardbell @Foxandxss 