### PR TITLE
chore(tests): add single run mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: trusty
+sudo: required
+language: node_js
+node_js:
+  - "5"
+os:
+  - linux
+env:
+  global:
+    - DBUS_SESSION_BUS_ADDRESS=/dev/null
+    - DISPLAY=:99.0
+    - CHROME_BIN=chromium-browser
+before_script:
+  - sh -e /etc/init.d/xvfb start
+install:
+  - npm install
+script:
+  - npm run lint
+  - npm run test-once 
+  - npm run e2e

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "docker-build": "docker build -t ng2-quickstart .",
     "docker": "npm run docker-build && docker run -it --rm -p 3000:3000 -p 3001:3001 ng2-quickstart",
     "pree2e": "npm run webdriver:update",
-    "e2e": "tsc && concurrently \"http-server\" \"protractor protractor.config.js\"",
+    "e2e": "tsc && concurrently \"http-server -s\" \"protractor protractor.config.js\" --kill-others --success first",
     "lint": "tslint ./app/**/*.ts -t verbose",
     "lite": "lite-server",
     "postinstall": "typings install",
     "test": "tsc && concurrently \"tsc -w\" \"karma start karma.conf.js\"",
+    "test-once": "tsc && karma start karma.conf.js --single-run",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "typings": "typings",
@@ -42,7 +43,7 @@
     "bootstrap": "^3.3.6"
   },
   "devDependencies": {
-    "concurrently": "^2.0.0",
+    "concurrently": "^2.2.0",
     "lite-server": "^2.2.0",
     "typescript": "^1.8.10",
     "typings": "^1.0.4",


### PR DESCRIPTION
This PR does a couple of things:
- adds a `test-once` npm script that runs karma in single run mode
- fixes the `e2e` script to exist automatically once protractor finishes
- runs `http-server` in the `e2e` script in silent mode, to make it easier to see test results
- runs lint, unit and e2e tests in Travis CI

/cc @wardbell @Foxandxss 