### PR TITLE
made dependent package versions explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,32 +34,32 @@
     "@angular/upgrade":  "2.0.0-rc.5",
 
     "systemjs": "0.19.27",
-    "core-js": "^2.4.0",
-    "reflect-metadata": "^0.1.3",
+    "core-js": "2.4.0",
+    "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.6",
-    "zone.js": "^0.6.12",
+    "zone.js": "0.6.12",
 
     "angular2-in-memory-web-api": "0.0.15",
-    "bootstrap": "^3.3.6"
+    "bootstrap": "3.3.6"
   },
   "devDependencies": {
-    "concurrently": "^2.2.0",
-    "lite-server": "^2.2.0",
-    "typescript": "^1.8.10",
-    "typings": "^1.0.4",
+    "concurrently": "2.2.0",
+    "lite-server": "2.2.0",
+    "typescript": "1.8.10",
+    "typings": "1.0.4",
 
     "canonical-path": "0.0.2",
-    "http-server": "^0.9.0",
-    "tslint": "^3.7.4",
-    "lodash": "^4.11.1",
-    "jasmine-core": "~2.4.1",
-    "karma": "^0.13.22",
-    "karma-chrome-launcher": "^0.2.3",
-    "karma-cli": "^0.1.2",
-    "karma-htmlfile-reporter": "^0.2.2",
-    "karma-jasmine": "^0.3.8",
-    "protractor": "^3.3.0",
-    "rimraf": "^2.5.2"
+    "http-server": "0.9.0",
+    "tslint": "3.7.4",
+    "lodash": "4.11.1",
+    "jasmine-core": "2.4.1",
+    "karma": "0.13.22",
+    "karma-chrome-launcher": "0.2.3",
+    "karma-cli": "0.1.2",
+    "karma-htmlfile-reporter": "0.2.2",
+    "karma-jasmine": "0.3.8",
+    "protractor": "3.3.0",
+    "rimraf": "2.5.2"
   },
   "repository": {}
 }


### PR DESCRIPTION
I had trouble running the quickstart because of: https://github.com/angular/quickstart/issues/186

Both of these commands now work with a fresh git clone and npm install:
- npm start
- npm test

