### PR TITLE
Import FormsModule to be able to use ngModel in templates

### DIFF
--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -1,10 +1,11 @@
 import { NgModule }      from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
 
 import { AppComponent }  from './app.component';
 
 @NgModule({
-  imports: [ BrowserModule ],
+  imports: [ BrowserModule, FormsModule ],
   declarations: [ AppComponent ],
   bootstrap: [ AppComponent ]
 })


### PR DESCRIPTION
Be able to use ngModel (very used angular classic) in templates by default without the need to import here manually.