### PR TITLE
chore: update to TS2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "concurrently": "^2.2.0",
     "lite-server": "^2.2.0",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.2",
     "typings": "^1.0.4",
 
     "canonical-path": "0.0.2",


### PR DESCRIPTION
This PR updates TypeScript from 1.8.10 to 2.0.2. It does not replace `typings` with `@types`, that will happen in https://github.com/angular/quickstart/pull/157.