### PR TITLE
fix(e2e): create output dir if it doesn't exist

### DIFF
--- a/protractor.config.js
+++ b/protractor.config.js
@@ -129,7 +129,26 @@ function Reporter(options) {
     fs.appendFileSync(outputFile, output);
   };
 
+  function ensureDirectoryExistence(filePath) {
+    var dirname = path.dirname(filePath);
+    if (directoryExists(dirname)) {
+      return true;
+    }
+    ensureDirectoryExistence(dirname);
+    fs.mkdirSync(dirname);
+  }
+
+  function directoryExists(path) {
+    try {
+      return fs.statSync(path).isDirectory();
+    }
+    catch (err) {
+      return false;
+    }
+  }
+
   function initOutputFile(outputFile) {
+    ensureDirectoryExistence(outputFile);
     var header = "Protractor results for: " + (new Date()).toLocaleString() + "\n\n";
     fs.writeFileSync(outputFile, header);
   }


### PR DESCRIPTION
Running `npm run e2e` without running `npm test` first will fail, because our protractor tests attempt to write to `./_test-output/protractor-results.txt` but `./_test-output/` does not exist yet.

Fix #196
Fix #201