### PR TITLE
use systemjs for all dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">
-
-    <!-- Polyfill(s) for older browsers -->
-    <script src="node_modules/core-js/client/shim.min.js"></script>
-
-    <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app').catch(function(err){ console.error(err); });

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -24,6 +24,9 @@
       '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
 
       // other libraries
+      'core':                       'npm:core-js/client/shim.min.js',
+      'zone':                       'npm:zone.js/dist/zone.js',
+      'reflect':                    'npm:reflect-metadata/Reflect.js',
       'rxjs':                       'npm:rxjs',
       'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
     },
@@ -39,6 +42,11 @@
       'angular2-in-memory-web-api': {
         main: './index.js',
         defaultExtension: 'js'
+      }
+    },
+    meta: {
+      'npm:@angular/*': {
+        deps: ['core', 'zone', 'reflect']
       }
     }
   });


### PR DESCRIPTION
My apologise in advance if this isn't appropriate, I just thought it more consistent/neater/tidier to use systemjs for loading all dependencies rather than having some in systemjs and some hard coded in the index.html