### PR TITLE
mistake in the name of the 'angular-in-memory-web-api' module

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@angular/router":  "~3.0.1",
     "@angular/upgrade":  "~2.0.1",
 
-    "angular-in-memory-web-api": "~0.1.1",
+    "angular2-in-memory-web-api": "~0.1.1",
     "bootstrap": "^3.3.7",
     "systemjs": "0.19.39",
     "core-js": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@angular/router":  "~3.0.1",
     "@angular/upgrade":  "~2.0.1",
 
-    "angular2-in-memory-web-api": "~0.1.1",
+    "angular2-in-memory-web-api": "~0.0.20",
     "bootstrap": "^3.3.7",
     "systemjs": "0.19.39",
     "core-js": "^2.4.1",

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -26,7 +26,7 @@
 
       // other libraries
       'rxjs':                      'npm:rxjs',
-      'angular-in-memory-web-api': 'npm:angular-in-memory-web-api',
+      'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
     },
     // packages tells the System loader how to load when no filename and/or no extension
     packages: {
@@ -37,7 +37,7 @@
       rxjs: {
         defaultExtension: 'js'
       },
-      'angular-in-memory-web-api': {
+      'angular2-in-memory-web-api': {
         main: './index.js',
         defaultExtension: 'js'
       }


### PR DESCRIPTION
I did not understand why i get 404 error, when i started the HTTP chapter

and in stackoverflow.com i seen the answer:
http://stackoverflow.com/a/37390321/3893414

So you have to fix the name to `angular2`...

Also please fix the documentation in angular.io:
https://angular.io/docs/ts/latest/tutorial/toh-pt6.html :
the importing in  `app/memory-data.service.ts` and `app/app.module.ts` files