### PR TITLE
Add node_modules to TS exclude

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,8 @@
     "removeComments": false,
     "noImplicitAny": true,
     "suppressImplicitAnyIndexErrors": true
-  }
+  },
+  "exclude": [
+  "node_modules"
+]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "suppressImplicitAnyIndexErrors": true
   },
   "exclude": [
-  "node_modules"
-]
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Add `node_modules` to the `exclude` in `tsconfig.json` to prevent editors from trying to parse every `.ts` file inside `node_modules`.

---

One of the main selling points of TypeScript is the autocompletion, and error checkings that it enables.

But not excluding `node_modules` from the TS files to compile can make the autocompletion and error checking useless in some editors.

In my case, it's [Atom](https://atom.io/) with [atom-typescript](https://atom.io/packages/atom-typescript). But I think it's probable that it happens in other editors too.

Every keystroke triggers a new parse / compile of the files to provide autocompletion and error checking, but reading all the files in `node_modules` takes several seconds, that sum at every new keystroke.

After adding `node_modules` to the `exclude` section it works perfectly (and now I'm really liking it).