### PR TITLE
chore: remove "run as admin" advice from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ git push -u origin master
 
 Install the npm packages described in the `package.json` and verify that it works:
 
-**Attention Windows Developers:  You must run all of these commands in administrator mode**.
-
 ```bash
 npm install
 npm start


### PR DESCRIPTION
removed advice about requiring admin access for npm install, start - this is incorrect and bad practise.