### PR TITLE
chore(editorconfig): remove end_of_line setting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,6 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 2
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Using `end_of_line` causes issues on windows machines.