### PR TITLE
chore(testing): revert to jasmine v.2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Upgraders: to be sure of a fresh start, consider running these commands
 * `npm install`
 * `npm run webdriver:update`
 
+<a name="0.2.15"></a>
+# 0.2.15 (2016-10-29)
+* Revert to Jasmine 2.4.1 because bug in 2.5.x (see [jasmine issue #1231](https://github.com/jasmine/jasmine/issues/1231))
+
 <a name="0.2.14"></a>
 # 0.2.14 (2016-10-29)
 * Remove bootstrap.css install

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "http-server": "^0.9.0",
     "tslint": "^3.15.1",
     "lodash": "^4.16.4",
-    "jasmine-core": "~2.5.2",
+    "jasmine-core": "~2.4.1",
     "karma": "^1.3.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-cli": "^1.0.1",


### PR DESCRIPTION
Bug in Jasmine v.2.5.x, reported in https://github.com/jasmine/jasmine/issues/1231

Stick with v.2.4.1 (as karma-jasmine does) until the issue is resolved
Unfortunately, there is no @types/jasmine for v.2.4 but only for v.2.5.