### PR TITLE
Generate code coverage of typescript code for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ e2e/**/*.js
 e2e/**/*.js.map
 _test-output
 _temp
+coverage-report

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,9 @@ module.exports = function(config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'), // click "Debug" in browser to see it
-      require('karma-htmlfile-reporter') // crashing w/ strange socket error
+      require('karma-htmlfile-reporter'), // crashing w/ strange socket error
+      require('karma-sourcemap-loader'),
+      require('karma-coverage')
     ],
 
     customLaunchers: {
@@ -80,9 +82,15 @@ module.exports = function(config) {
     },
 
     exclude: [],
-    preprocessors: {},
+    preprocessors: {
+      // source files, that you wanna generate coverage for
+      // do not include tests or libraries
+      // (these files will be instrumented by Istanbul)
+      'app/**/!(*.spec).js': ['coverage'],
+      'app/**/*.js': ['sourcemap']      
+    },
     // disabled HtmlReporter; suddenly crashing w/ strange socket error
-    reporters: ['progress', 'kjhtml'],//'html'],
+    reporters: ['progress', 'kjhtml', 'coverage'],//'html'],
 
     // HtmlReporter configuration
     htmlReporter: {
@@ -93,7 +101,17 @@ module.exports = function(config) {
       pageTitle: 'Unit Tests',
       subPageTitle: __dirname
     },
+    // generate coverage report in json format.
+    // it is generated in .temp folder because it needs
+    // to be re-mapped to its typescript sources 
+    coverageReporter: {
+        dir: 'coverage-report/.temp/',
+        reporters: [
+            {type: 'json', subdir: 'report-json'}
+        ],
+        includeAllSources: true
 
+    },
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lite": "lite-server",
     "test": "tsc && concurrently \"tsc -w\" \"karma start karma.conf.js\"",
     "test-once": "tsc && karma start karma.conf.js --single-run",
+    "test-once-cover": "rimraf coverage-report/ && npm run test-once && remap-istanbul -i ./coverage-report/.temp/report-json/coverage-final.json -o ./coverage-report/remapped/html-report -t html --exclude node_modules,tests,app/main.ts",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "webdriver:update": "webdriver-manager update"
@@ -34,7 +35,6 @@
     "@angular/platform-browser-dynamic": "~2.2.0",
     "@angular/router": "~3.2.0",
     "@angular/upgrade": "~2.2.0",
-
     "angular-in-memory-web-api": "~0.1.15",
     "systemjs": "0.19.40",
     "core-js": "^2.4.1",
@@ -43,29 +43,30 @@
     "zone.js": "^0.6.26"
   },
   "devDependencies": {
-    "concurrently": "^3.1.0",
-    "lite-server": "^2.2.2",
-    "typescript": "^2.0.3",
-
+    "@types/core-js": "^0.9.34",
+    "@types/jasmine": "^2.5.36",
+    "@types/node": "^6.0.46",
+    "@types/selenium-webdriver": "^2.53.33",
     "canonical-path": "0.0.2",
+    "concurrently": "^3.1.0",
     "http-server": "^0.9.0",
-    "tslint": "^3.15.1",
-    "lodash": "^4.16.4",
     "jasmine-core": "~2.4.1",
     "karma": "^1.3.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-cli": "^1.0.1",
+    "karma-coverage": "^1.1.1",
     "karma-htmlfile-reporter": "^0.3.4",
     "karma-jasmine": "^1.0.2",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "karma-sourcemap-loader": "^0.3.7",
+    "lite-server": "^2.2.2",
+    "lodash": "^4.16.4",
     "protractor": "4.0.9",
-    "webdriver-manager": "10.2.5",
+    "remap-istanbul": "^0.7.0",
     "rimraf": "^2.5.4",
-
-    "@types/core-js": "^0.9.34",
-    "@types/node": "^6.0.46",
-    "@types/jasmine": "^2.5.36",
-    "@types/selenium-webdriver": "^2.53.33"
+    "tslint": "^3.15.1",
+    "typescript": "^2.0.3",
+    "webdriver-manager": "10.2.5"
   },
   "repository": {}
 }


### PR DESCRIPTION
Changes made:
1. Added npm packages: karma-coverage, karma-sourcemap-loader and remap-istanbul
2. updated karma.conf.js to use the newly added packages to generate coverage of transpiled code
3. added npm test : test-once-cover to generate coverage report in html format

Steps followed to generate code coverage:
1. Using karma-coverage and karma-sourcemap-loader, karma generates code coverage of transpiled files
2. using remap-istanbul package, the coverage of typescript code is generated
3  The code coverage report is finally generated in html format under coverage-report/remapped/html-report/ folder.
