### PR TITLE
Correction for when we change tsconfig.json/outDir and karma.conf/appBase

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
     ],
 
     client: {
-      builtPaths: [appSrcBase, testingBase], // add more spec base paths as needed
+      builtPaths: [appBase, testingBase], // add more spec base paths as needed
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
 


### PR DESCRIPTION
Usage of the variable currently works only because appBase and appSrcBase are defined to the same thing, but is conceptually incorrect.