### PR TITLE
ci: update protractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "4.0.9",
-    "webdriver-manager": "10.2.5",
+    "protractor": "~4.0.13",
     "rimraf": "^2.5.4",
 
     "@types/node": "^6.0.46",


### PR DESCRIPTION
Followup to https://github.com/angular/quickstart/pull/266, it is no longer needed.

/cc @wardbell @Foxandxss @cnishina 