### PR TITLE
Fixed dependency binding

### DIFF
--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -1,10 +1,10 @@
 import { NgModule }      from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-
+import { FormsModule }   from '@angular/forms';
 import { AppComponent }  from './app.component';
 
 @NgModule({
-  imports:      [ BrowserModule ],
+  imports:      [ BrowserModule, FormsModule ],
   declarations: [ AppComponent ],
   bootstrap:    [ AppComponent ]
 })


### PR DESCRIPTION
Due to a problem with the quickstart repo, the Angular Tutorial: https://angular.io/docs/ts/latest/tutorial/toh-pt2.html drop an error.

After binding FormsModule it worked