### PR TITLE
fix(deps): pin webdriver and zone.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.0-rc.4",
-    "zone.js": "^0.7.2"
+    "zone.js": "0.7.2"
   },
   "devDependencies": {
     "concurrently": "^3.1.0",
@@ -53,7 +53,7 @@
 
     "@types/node": "^6.0.46",
     "@types/jasmine": "^2.5.36",
-    "@types/selenium-webdriver": "^2.53.33"
+    "@types/selenium-webdriver": "2.53.33"
   },
   "repository": {}
 }


### PR DESCRIPTION
When https://github.com/angular/protractor/pull/3848 is ready it should fix the webdriver types issues, and the pinning can be reverted.

The zone.js problem is being tracked on https://github.com/angular/zone.js/issues/554.

Fix https://github.com/angular/quickstart/issues/325