### PR TITLE
fix(deps): remove selenium-webdriver typings and update protractor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,12 +48,11 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "~4.0.13",
+    "protractor": "~4.0.14",
     "rimraf": "^2.5.4",
 
     "@types/node": "^6.0.46",
-    "@types/jasmine": "^2.5.36",
-    "@types/selenium-webdriver": "2.53.33"
+    "@types/jasmine": "^2.5.36"
   },
   "repository": {}
 }


### PR DESCRIPTION
The `@types/selenium-webdriver` is not needed since the types are a dependency of Protractor. Updating to the latest Protractor version. The new version pins the version of `@types/selenium-webdriver` to prevent issues with upstream dependencies like #325.