### PR TITLE
Update karma.conf.js to fix #329

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@ module.exports = function(config) {
 
   var appBase    = 'app/';      // transpiled app JS and map files
   var appSrcBase = 'app/';      // app source TS files
-  var appAssets  = 'base/app/'; // component assets fetched by Angular's compiler
+  var appAssets  = '/base/app/'; // component assets fetched by Angular's compiler
 
   // Testing helpers (optional) are conventionally in a folder called `testing`
   var testingBase    = 'testing/'; // transpiled test JS and map files


### PR DESCRIPTION
Fixes "Testing components using templateUrl fails with setup from this quickstart #329"

Tests run by karma were not resolving the templateUrl correctly.

See Issue: https://github.com/angular/quickstart/issues/329