### PR TITLE
chore(deps): remove reflect-metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,7 +38,6 @@ module.exports = function(config) {
 
       // Polyfills
       'node_modules/core-js/client/shim.js',
-      'node_modules/reflect-metadata/Reflect.js',
 
       // zone.js
       'node_modules/zone.js/dist/zone.js',

--- a/package.json
+++ b/package.json
@@ -26,10 +26,9 @@
     "@angular/platform-browser-dynamic": "~2.4.0",
     "@angular/router": "~3.4.0",
 
-    "angular-in-memory-web-api": "~0.2.2",
+    "angular-in-memory-web-api": "~0.2.4",
     "systemjs": "0.19.40",
     "core-js": "^2.4.1",
-    "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.1",
     "zone.js": "^0.7.4"
   },


### PR DESCRIPTION
Blocked on https://github.com/angular/in-memory-web-api/pull/86
Should be merged together with https://github.com/angular/angular.io/pull/3058

As per https://github.com/zloirock/core-js/issues/152, `core-js` already includes `reflect-metadata`.

/cc @wardbell @Foxandxss 