### PR TITLE
fix description for removing non-essential-files on Mac OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ by entering the following commands while in the project folder:
 
 ##### OS/X (bash)
 ```shell
-xargs -a non-essential-files.txt rm -rf
+cat non-essential-files.txt | tr -d '\r' | xargs rm -rf
 rm app/*.spec*.ts
-rm non-essential-files.txt
 ```
 
 ##### Windows


### PR DESCRIPTION
Described command line fails because:
- BSD `xargs` does not have `-a` option.
- `non-essential-files.txt` has CRLF line terminators.