### PR TITLE
Turn "no-inferrable-types" parameter in an array

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -40,7 +40,7 @@
     "no-duplicate-variable": true,
     "no-empty": false,
     "no-eval": true,
-    "no-inferrable-types": true,
+    "no-inferrable-types": [ true ],
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-switch-case-fall-through": true,


### PR DESCRIPTION
In tslint.json  "no-inferrable-types" parameter must be an array