### PR TITLE
npm run build:w => npm run build:watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ We've captured many of the most useful commands in npm scripts defined in the `p
 
 * `npm start` - runs the compiler and a server at the same time, both in "watch mode".
 * `npm run build` - runs the TypeScript compiler once.
-* `npm run build:w` - runs the TypeScript compiler in watch mode; the process keeps running, awaiting changes to TypeScript files and re-compiling when it sees them.
+* `npm run build:watch` - runs the TypeScript compiler in watch mode; the process keeps running, awaiting changes to TypeScript files and re-compiling when it sees them.
 * `npm run serve` - runs the [lite-server](https://www.npmjs.com/package/lite-server), a light-weight, static file server, written and maintained by
 [John Papa](https://github.com/johnpapa) and
 [Christopher Martin](https://github.com/cgmartin)


### PR DESCRIPTION
Starting from a new quickstart installation I have found that build:w does not work, where build:watch does.