### PR TITLE
Changing the default application port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You're ready to write your application.
 
 We've captured many of the most useful commands in npm scripts defined in the `package.json`:
 
-* `npm start` - runs the compiler and a server at the same time, both in "watch mode".
+* `npm start` - runs the compiler and a server at the same time, both in "watch mode". If you want, you can change the default application port by adding `"port": xxxx` in `bs-config.json`.
 * `npm run build` - runs the TypeScript compiler once.
 * `npm run build:w` - runs the TypeScript compiler in watch mode; the process keeps running, awaiting changes to TypeScript files and re-compiling when it sees them.
 * `npm run serve` - runs the [lite-server](https://www.npmjs.com/package/lite-server), a light-weight, static file server, written and maintained by


### PR DESCRIPTION
Often developers get confuse about running two AngularJs applications at same time, it is mandatory for the them to know about changing default application port to another, so they can run as many applications of AngularJs at same time.