### PR TITLE
Add import for FormsModule to support ngModel.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,10 +1,14 @@
 import { NgModule }      from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule }   from '@angular/forms';
 
 import { AppComponent }  from './app.component';
 
 @NgModule({
-  imports:      [ BrowserModule ],
+  imports:      [ 
+    BrowserModule,
+    FormsModule
+  ],
   declarations: [ AppComponent ],
   bootstrap:    [ AppComponent ]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { FormsModule }   from '@angular/forms';
 import { AppComponent }  from './app.component';
 
 @NgModule({
-  imports:      [ 
+  imports: [
     BrowserModule,
     FormsModule
   ],


### PR DESCRIPTION
Current code has error "Can't bind to 'ngModel' since it isn't a known property" once ngModel is added to a template property or .html file.

If followed instructions at https://angular.io/docs/ts/latest/tutorial/toh-pt1.html#!#two-way-binding to include an import for FormsModule in the app.module.ts file.