### PR TITLE
Fix systemjs-angular-loader.js for <=IE10

### DIFF
--- a/src/systemjs-angular-loader.js
+++ b/src/systemjs-angular-loader.js
@@ -19,7 +19,7 @@ module.exports.translate = function(load){
 
   load.source = load.source
     .replace(templateUrlRegex, function(match, quote, url){
-      let resolvedUrl = url;
+      var resolvedUrl = url;
 
       if (url.startsWith('.')) {
         resolvedUrl = basePath + url.substr(1);


### PR DESCRIPTION
"let" is ES2015 and therefore not supported by<=IE10