### PR TITLE
Fix systemjs-angular-loader.js for external templates (#444)

### DIFF
--- a/src/systemjs-angular-loader.js
+++ b/src/systemjs-angular-loader.js
@@ -3,6 +3,8 @@ var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
 var stringRegex = /(['`"])((?:[^\\]\\\1|.)*?)\1/g;
 
 module.exports.translate = function(load){
+  if (load.source.indexOf('moduleId') != -1) return load;
+
   var url = document.createElement('a');
   url.href = load.address;
 
@@ -15,7 +17,9 @@ module.exports.translate = function(load){
   baseHref.href = this.baseURL;
   baseHref = baseHref.pathname;
 
-  basePath = basePath.replace(baseHref, '');
+  if (!baseHref.startsWith('/base/')) { // it is not karma
+    basePath = basePath.replace(baseHref, '');
+  }
 
   load.source = load.source
     .replace(templateUrlRegex, function(match, quote, url){


### PR DESCRIPTION
these code changes are based on code found in the angular docs [component with external testing](https://angular.io/docs/ts/latest/guide/testing.html#!#component-with-external-template) downloadable example.

Although the refactoring I described in #444 seems pretty simple enough to understand, In my fork  you can see branches demonstrate-bug-444 & demonstrate-fix-444 for more context of this bug and how this fix it.  

I'm assuming because this code came from elsewhere in angular help/tutorial that it's okay.. but as a sidenote, the "indexof('moduleId')" seems rather poor because if you've got the word "moduleId" _anywhere_ (for example, in a line of sourcecode you just commented out) it, the module fails to load the template.  Not sure what the better solution would be, just my $0.02