### PR TITLE
update package.json to make quickstart work again from installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "angular-in-memory-web-api": "~0.3.0",
     "systemjs": "0.19.40",
     "core-js": "^2.4.1",
-    "rxjs": "5.0.1",
-    "zone.js": "^0.8.4"
+    "rxjs": "^5.4.2",
+    "zone.js": "^0.8.4",
+    "typescript": "^2.3.4"
   },
   "devDependencies": {
     "concurrently": "^3.2.0",
     "lite-server": "^2.2.2",
-    "typescript": "~2.1.0",
 
     "canonical-path": "0.0.2",
     "tslint": "^3.15.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "~4.0.14",
+    "protractor": "~5.1.0",
     "rimraf": "^2.5.4",
 
     "@types/node": "^6.0.46",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "angular-quickstart",
   "version": "1.0.0",
   "description": "QuickStart package.json from the documentation, supplemented with testing support",
+  "engines" : { "node" : "^6.11.2" }, 
   "scripts": {
     "build": "tsc -p src/",
     "build:watch": "tsc -p src/ -w",


### PR DESCRIPTION
Move typescript out of the dev dependencies, so npm will also auto install it.
Put in a higher version of rxjs and typescript to avoid problems with lift() function.
Tested on a clean windows system (after installing only npm), but no e2e yet